### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ git log
 // in the text editor pick the oldest commit and squash the rest
 // see commits in next window and hit :qw
 
-git rebase -i HEAD~<num of commits>
+git -i rebase HEAD~<num of commits>
 git push --force
 
 // these prior steps will "squash" together all of the commits on your branch, so you only have to rebase your branch against


### PR DESCRIPTION
Fixed a typo in the README. '-i' was after rebase not before